### PR TITLE
ReferenceEquals instead of Equals in DbExpressionVisitor_VisitBinaryExpression

### DIFF
--- a/DbExpressions/Visitors/DbExpressionVisitor.cs
+++ b/DbExpressions/Visitors/DbExpressionVisitor.cs
@@ -103,8 +103,8 @@ namespace DbExpressions
         {
             var leftExpression = Visit(binaryExpression.LeftExpression);
             var rightExpression = Visit(binaryExpression.RightExpression);
-            if (!leftExpression.Equals(binaryExpression.LeftExpression) ||
-                !rightExpression.Equals(binaryExpression.RightExpression))
+            if (!ReferenceEquals(leftExpression, binaryExpression.LeftExpression) ||
+                !ReferenceEquals(rightExpression, binaryExpression.RightExpression))
             {
                 return ExpressionFactory.MakeBinary(binaryExpression.BinaryExpressionType, leftExpression, rightExpression);
             }


### PR DESCRIPTION
ReferenceEquals is used throughout the DbExpressionVisitor class except the VisitBinaryExpression method...isn't that just an oversight?